### PR TITLE
Fix Exception when -l and dir_path = None

### DIFF
--- a/DumpSMBShare.py
+++ b/DumpSMBShare.py
@@ -199,7 +199,10 @@ if __name__ == "__main__":
     try:
         smbClient = init_smb_session(args, domain, username, password, address, lmhash, nthash)
         if args.list_shares:
-            g = BFSDumpShare(smbClient, args.share, dump_dir=args.dump_dir)
+            if args.dump_dir is None:
+                g = BFSDumpShare(smbClient, args.share)
+            else:
+                g = BFSDumpShare(smbClient, args.share, dump_dir=args.dump_dir)
             shares = g.list_shares()
             for s in shares:
                 print("  - %s" % s)


### PR DESCRIPTION
Env: Manjaro, python 3.10

When running a list share and not specifiying DUMP_DIR, we get:
```bash
$ python DumpSMBShare.py '42.42.42.42' -l
DumpSMBShare v1.2 - by @podalirius_

Traceback (most recent call last):
  File "/usr/bin/dumpsmbshare", line 222, in <module>
    raise e
  File "/usr/bin/dumpsmbshare", line 202, in <module>
    g = BFSDumpShare(smbClient, args.share, dump_dir=args.dump_dir)
  File "/usr/bin/dumpsmbshare", line 28, in __init__
    if not os.path.exists(self.dump_dir):
  File "/usr/lib/python3.10/genericpath.py", line 19, in exists
    os.stat(path)
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType
```

My commit fixes that.

Passing `dump_dir=None` prevents the default value to be set on `.`, omiting it works as expected.